### PR TITLE
Add "workflow" as a module section to experimental modules

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1032,6 +1032,7 @@ def load_module_sections( trans ):
             "title": "Experimental",
             "modules": [
                 {"name": "pause", "title": "Pause Workflow for Dataset Review", "description": "Pause for Review"},
+                {"name": "workflow", "title": "Allow sub-workflows", "description": "Allow workflows to be included as tools in other workflows"}
             ],
         }
         module_sections.append(experimental_modules)


### PR DESCRIPTION
load_module_section in modules.py is used to supply a list of modules to load to the 
workflow controller. I've added workflow as a module section to load _if_ experimental 
workflow modules are enabled in the Galaxy config.
